### PR TITLE
複数の設定をプロファイルとして管理できるようにする

### DIFF
--- a/oneHandleInput/ConfigForm.Designer.cs
+++ b/oneHandleInput/ConfigForm.Designer.cs
@@ -62,6 +62,14 @@
             this.label10 = new System.Windows.Forms.Label();
             this.txtReverserFront = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label46 = new System.Windows.Forms.Label();
+            this.label43 = new System.Windows.Forms.Label();
+            this.label44 = new System.Windows.Forms.Label();
+            this.label45 = new System.Windows.Forms.Label();
+            this.txtSwConstSpeed = new System.Windows.Forms.TextBox();
+            this.txtSwMusicHorn = new System.Windows.Forms.TextBox();
+            this.txtSwHorn2 = new System.Windows.Forms.TextBox();
+            this.txtSwHorn1 = new System.Windows.Forms.TextBox();
             this.label42 = new System.Windows.Forms.Label();
             this.label41 = new System.Windows.Forms.Label();
             this.label40 = new System.Windows.Forms.Label();
@@ -129,14 +137,10 @@
             this.label37 = new System.Windows.Forms.Label();
             this.txtSsbMax = new System.Windows.Forms.TextBox();
             this.label38 = new System.Windows.Forms.Label();
-            this.txtSwMusicHorn = new System.Windows.Forms.TextBox();
-            this.txtSwHorn2 = new System.Windows.Forms.TextBox();
-            this.txtSwHorn1 = new System.Windows.Forms.TextBox();
-            this.txtSwConstSpeed = new System.Windows.Forms.TextBox();
-            this.label43 = new System.Windows.Forms.Label();
-            this.label44 = new System.Windows.Forms.Label();
-            this.label45 = new System.Windows.Forms.Label();
-            this.label46 = new System.Windows.Forms.Label();
+            this.groupBox8 = new System.Windows.Forms.GroupBox();
+            this.label47 = new System.Windows.Forms.Label();
+            this.cmbProfileSelect = new System.Windows.Forms.ComboBox();
+            this.btnSaveAs = new System.Windows.Forms.Button();
             this.groupBox2.SuspendLayout();
             this.groupBox3.SuspendLayout();
             this.groupBox4.SuspendLayout();
@@ -144,6 +148,7 @@
             this.groupBox5.SuspendLayout();
             this.groupBox6.SuspendLayout();
             this.groupBox7.SuspendLayout();
+            this.groupBox8.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox2
@@ -161,7 +166,7 @@
             this.groupBox2.Controls.Add(this.label4);
             this.groupBox2.Controls.Add(this.label3);
             this.groupBox2.Controls.Add(this.txtBrakeEmr);
-            this.groupBox2.Location = new System.Drawing.Point(216, 12);
+            this.groupBox2.Location = new System.Drawing.Point(216, 18);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(195, 175);
             this.groupBox2.TabIndex = 4;
@@ -287,7 +292,7 @@
             this.groupBox3.Controls.Add(this.label6);
             this.groupBox3.Controls.Add(this.txtPowerMax);
             this.groupBox3.Controls.Add(this.label5);
-            this.groupBox3.Location = new System.Drawing.Point(216, 193);
+            this.groupBox3.Location = new System.Drawing.Point(216, 199);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(195, 140);
             this.groupBox3.TabIndex = 5;
@@ -379,7 +384,7 @@
             this.groupBox4.Controls.Add(this.label8);
             this.groupBox4.Controls.Add(this.label10);
             this.groupBox4.Controls.Add(this.txtReverserFront);
-            this.groupBox4.Location = new System.Drawing.Point(39, 12);
+            this.groupBox4.Location = new System.Drawing.Point(39, 18);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Size = new System.Drawing.Size(137, 172);
             this.groupBox4.TabIndex = 6;
@@ -494,12 +499,84 @@
             this.groupBox1.Controls.Add(this.label14);
             this.groupBox1.Controls.Add(this.txtSwS);
             this.groupBox1.Controls.Add(this.label13);
-            this.groupBox1.Location = new System.Drawing.Point(417, 14);
+            this.groupBox1.Location = new System.Drawing.Point(417, 20);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(228, 320);
             this.groupBox1.TabIndex = 7;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "スイッチ";
+            // 
+            // label46
+            // 
+            this.label46.AutoSize = true;
+            this.label46.Location = new System.Drawing.Point(104, 267);
+            this.label46.Name = "label46";
+            this.label46.Size = new System.Drawing.Size(29, 12);
+            this.label46.TabIndex = 46;
+            this.label46.Text = "定速";
+            // 
+            // label43
+            // 
+            this.label43.AutoSize = true;
+            this.label43.Location = new System.Drawing.Point(107, 243);
+            this.label43.Name = "label43";
+            this.label43.Size = new System.Drawing.Size(22, 12);
+            this.label43.TabIndex = 45;
+            this.label43.Text = "MH";
+            // 
+            // label44
+            // 
+            this.label44.AutoSize = true;
+            this.label44.Location = new System.Drawing.Point(106, 219);
+            this.label44.Name = "label44";
+            this.label44.Size = new System.Drawing.Size(23, 12);
+            this.label44.TabIndex = 44;
+            this.label44.Text = "笛2";
+            // 
+            // label45
+            // 
+            this.label45.AutoSize = true;
+            this.label45.Location = new System.Drawing.Point(106, 192);
+            this.label45.Name = "label45";
+            this.label45.Size = new System.Drawing.Size(23, 12);
+            this.label45.TabIndex = 43;
+            this.label45.Text = "笛1";
+            // 
+            // txtSwConstSpeed
+            // 
+            this.txtSwConstSpeed.Location = new System.Drawing.Point(133, 264);
+            this.txtSwConstSpeed.Name = "txtSwConstSpeed";
+            this.txtSwConstSpeed.ReadOnly = true;
+            this.txtSwConstSpeed.Size = new System.Drawing.Size(76, 19);
+            this.txtSwConstSpeed.TabIndex = 42;
+            this.txtSwConstSpeed.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
+            // 
+            // txtSwMusicHorn
+            // 
+            this.txtSwMusicHorn.Location = new System.Drawing.Point(133, 240);
+            this.txtSwMusicHorn.Name = "txtSwMusicHorn";
+            this.txtSwMusicHorn.ReadOnly = true;
+            this.txtSwMusicHorn.Size = new System.Drawing.Size(76, 19);
+            this.txtSwMusicHorn.TabIndex = 41;
+            this.txtSwMusicHorn.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
+            // 
+            // txtSwHorn2
+            // 
+            this.txtSwHorn2.Location = new System.Drawing.Point(133, 215);
+            this.txtSwHorn2.Name = "txtSwHorn2";
+            this.txtSwHorn2.ReadOnly = true;
+            this.txtSwHorn2.Size = new System.Drawing.Size(76, 19);
+            this.txtSwHorn2.TabIndex = 40;
+            this.txtSwHorn2.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
+            // 
+            // txtSwHorn1
+            // 
+            this.txtSwHorn1.Location = new System.Drawing.Point(133, 189);
+            this.txtSwHorn1.Name = "txtSwHorn1";
+            this.txtSwHorn1.ReadOnly = true;
+            this.txtSwHorn1.Size = new System.Drawing.Size(76, 19);
+            this.txtSwHorn1.TabIndex = 39;
+            this.txtSwHorn1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
             // 
             // label42
             // 
@@ -846,7 +923,7 @@
             // groupBox5
             // 
             this.groupBox5.Controls.Add(this.cmbJoySelect);
-            this.groupBox5.Location = new System.Drawing.Point(663, 212);
+            this.groupBox5.Location = new System.Drawing.Point(678, 244);
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.Size = new System.Drawing.Size(179, 49);
             this.groupBox5.TabIndex = 8;
@@ -865,17 +942,17 @@
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(663, 267);
+            this.btnSave.Location = new System.Drawing.Point(678, 307);
             this.btnSave.Name = "btnSave";
-            this.btnSave.Size = new System.Drawing.Size(87, 69);
+            this.btnSave.Size = new System.Drawing.Size(87, 44);
             this.btnSave.TabIndex = 9;
-            this.btnSave.Text = "保存して閉じる";
+            this.btnSave.Text = "上書き保存";
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
             // 
             // btnClose
             // 
-            this.btnClose.Location = new System.Drawing.Point(766, 298);
+            this.btnClose.Location = new System.Drawing.Point(780, 360);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(76, 37);
             this.btnClose.TabIndex = 10;
@@ -898,7 +975,7 @@
             this.groupBox6.Controls.Add(this.label30);
             this.groupBox6.Controls.Add(this.txtInfoX);
             this.groupBox6.Controls.Add(this.label29);
-            this.groupBox6.Location = new System.Drawing.Point(663, 12);
+            this.groupBox6.Location = new System.Drawing.Point(678, 44);
             this.groupBox6.Name = "groupBox6";
             this.groupBox6.Size = new System.Drawing.Size(178, 194);
             this.groupBox6.TabIndex = 11;
@@ -1032,7 +1109,7 @@
             this.groupBox7.Controls.Add(this.label37);
             this.groupBox7.Controls.Add(this.txtSsbMax);
             this.groupBox7.Controls.Add(this.label38);
-            this.groupBox7.Location = new System.Drawing.Point(12, 194);
+            this.groupBox7.Location = new System.Drawing.Point(12, 200);
             this.groupBox7.Name = "groupBox7";
             this.groupBox7.Size = new System.Drawing.Size(195, 140);
             this.groupBox7.TabIndex = 12;
@@ -1115,93 +1192,62 @@
             this.label38.TabIndex = 2;
             this.label38.Text = "最大";
             // 
-            // txtSwMusicHorn
+            // groupBox8
             // 
-            this.txtSwMusicHorn.Location = new System.Drawing.Point(133, 240);
-            this.txtSwMusicHorn.Name = "txtSwMusicHorn";
-            this.txtSwMusicHorn.ReadOnly = true;
-            this.txtSwMusicHorn.Size = new System.Drawing.Size(76, 19);
-            this.txtSwMusicHorn.TabIndex = 41;
-            this.txtSwMusicHorn.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
+            this.groupBox8.Controls.Add(this.groupBox4);
+            this.groupBox8.Controls.Add(this.groupBox7);
+            this.groupBox8.Controls.Add(this.groupBox2);
+            this.groupBox8.Controls.Add(this.groupBox3);
+            this.groupBox8.Controls.Add(this.groupBox1);
+            this.groupBox8.Location = new System.Drawing.Point(12, 44);
+            this.groupBox8.Name = "groupBox8";
+            this.groupBox8.Size = new System.Drawing.Size(656, 353);
+            this.groupBox8.TabIndex = 13;
+            this.groupBox8.TabStop = false;
+            this.groupBox8.Text = "設定";
             // 
-            // txtSwHorn2
+            // label47
             // 
-            this.txtSwHorn2.Location = new System.Drawing.Point(133, 215);
-            this.txtSwHorn2.Name = "txtSwHorn2";
-            this.txtSwHorn2.ReadOnly = true;
-            this.txtSwHorn2.Size = new System.Drawing.Size(76, 19);
-            this.txtSwHorn2.TabIndex = 40;
-            this.txtSwHorn2.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
+            this.label47.AutoSize = true;
+            this.label47.Location = new System.Drawing.Point(10, 15);
+            this.label47.Name = "label47";
+            this.label47.Size = new System.Drawing.Size(57, 12);
+            this.label47.TabIndex = 14;
+            this.label47.Text = "プロファイル";
             // 
-            // txtSwHorn1
+            // cmbProfileSelect
             // 
-            this.txtSwHorn1.Location = new System.Drawing.Point(133, 189);
-            this.txtSwHorn1.Name = "txtSwHorn1";
-            this.txtSwHorn1.ReadOnly = true;
-            this.txtSwHorn1.Size = new System.Drawing.Size(76, 19);
-            this.txtSwHorn1.TabIndex = 39;
-            this.txtSwHorn1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
+            this.cmbProfileSelect.FormattingEnabled = true;
+            this.cmbProfileSelect.Location = new System.Drawing.Point(73, 12);
+            this.cmbProfileSelect.Name = "cmbProfileSelect";
+            this.cmbProfileSelect.Size = new System.Drawing.Size(300, 20);
+            this.cmbProfileSelect.TabIndex = 15;
+            this.cmbProfileSelect.SelectedValueChanged += new System.EventHandler(this.cmbProfileSelect_SelectedValueChanged);
             // 
-            // txtSwConstSpeed
+            // btnSaveAs
             // 
-            this.txtSwConstSpeed.Location = new System.Drawing.Point(133, 264);
-            this.txtSwConstSpeed.Name = "txtSwConstSpeed";
-            this.txtSwConstSpeed.ReadOnly = true;
-            this.txtSwConstSpeed.Size = new System.Drawing.Size(76, 19);
-            this.txtSwConstSpeed.TabIndex = 42;
-            this.txtSwConstSpeed.KeyDown += new System.Windows.Forms.KeyEventHandler(this.deconfigurateSwitch);
-            // 
-            // label43
-            // 
-            this.label43.AutoSize = true;
-            this.label43.Location = new System.Drawing.Point(107, 243);
-            this.label43.Name = "label43";
-            this.label43.Size = new System.Drawing.Size(22, 12);
-            this.label43.TabIndex = 45;
-            this.label43.Text = "MH";
-            // 
-            // label44
-            // 
-            this.label44.AutoSize = true;
-            this.label44.Location = new System.Drawing.Point(106, 219);
-            this.label44.Name = "label44";
-            this.label44.Size = new System.Drawing.Size(23, 12);
-            this.label44.TabIndex = 44;
-            this.label44.Text = "笛2";
-            // 
-            // label45
-            // 
-            this.label45.AutoSize = true;
-            this.label45.Location = new System.Drawing.Point(106, 192);
-            this.label45.Name = "label45";
-            this.label45.Size = new System.Drawing.Size(23, 12);
-            this.label45.TabIndex = 43;
-            this.label45.Text = "笛1";
-            // 
-            // label46
-            // 
-            this.label46.AutoSize = true;
-            this.label46.Location = new System.Drawing.Point(104, 267);
-            this.label46.Name = "label46";
-            this.label46.Size = new System.Drawing.Size(29, 12);
-            this.label46.TabIndex = 46;
-            this.label46.Text = "定速";
+            this.btnSaveAs.Location = new System.Drawing.Point(769, 307);
+            this.btnSaveAs.Name = "btnSaveAs";
+            this.btnSaveAs.Size = new System.Drawing.Size(87, 44);
+            this.btnSaveAs.TabIndex = 16;
+            this.btnSaveAs.Text = "名前を付けて保存";
+            this.btnSaveAs.UseVisualStyleBackColor = true;
+            this.btnSaveAs.Click += new System.EventHandler(this.btnSaveAs_Click);
             // 
             // ConfigForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(856, 346);
+            this.ClientSize = new System.Drawing.Size(868, 409);
             this.ControlBox = false;
-            this.Controls.Add(this.groupBox7);
+            this.Controls.Add(this.btnSaveAs);
+            this.Controls.Add(this.cmbProfileSelect);
+            this.Controls.Add(this.label47);
+            this.Controls.Add(this.groupBox8);
             this.Controls.Add(this.groupBox6);
+            this.Controls.Add(this.groupBox5);
             this.Controls.Add(this.btnClose);
             this.Controls.Add(this.btnSave);
-            this.Controls.Add(this.groupBox5);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.groupBox4);
-            this.Controls.Add(this.groupBox3);
-            this.Controls.Add(this.groupBox2);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Name = "ConfigForm";
             this.Text = "oneHandleInput";
@@ -1221,7 +1267,9 @@
             this.groupBox6.PerformLayout();
             this.groupBox7.ResumeLayout(false);
             this.groupBox7.PerformLayout();
+            this.groupBox8.ResumeLayout(false);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -1335,5 +1383,9 @@
         private System.Windows.Forms.TextBox txtSwMusicHorn;
         private System.Windows.Forms.TextBox txtSwHorn2;
         private System.Windows.Forms.TextBox txtSwHorn1;
+        private System.Windows.Forms.GroupBox groupBox8;
+        private System.Windows.Forms.Label label47;
+        private System.Windows.Forms.ComboBox cmbProfileSelect;
+        private System.Windows.Forms.Button btnSaveAs;
     }
 }

--- a/oneHandleInput/ConfigProfile.cs
+++ b/oneHandleInput/ConfigProfile.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace oneHandleInput
+{
+    public class ConfigProfile
+    {
+        public static ConfigProfile Empty;
+
+        public Guid guid;
+
+        public int reverserPosFront;
+        public int reverserPosBack;
+        public int reverserAxis;
+        public bool reverserAxisNegative;
+
+        public int brakePosEmr;
+        public int brakePosMax;
+        public int brakePosNeutral;
+        public int brakeNotches;
+        public int brakeChatter;
+        public int brakeAxis;
+        public bool brakeAxisNegative;
+
+        public int powerPosNeutral;
+        public int powerPosMax;
+        public int powerNotches;
+        public int powerAxis;
+        public bool powerAxisNegative;
+
+        public int ssbPosMax;
+        public int ssbPosNeutral;
+        public int ssbNotches;
+        public int ssbAxis;
+        public bool ssbAxisNegative;
+
+        public int switchS;
+        public int switchA1;
+        public int switchA2;
+        public int switchB1;
+        public int switchB2;
+        public int switchC1;
+        public int switchC2;
+        public int switchD;
+        public int switchE;
+        public int switchF;
+        public int switchG;
+        public int switchH;
+        public int switchI;
+        public int switchJ;
+        public int switchK;
+        public int switchL;
+        public int switchReverserFront;
+        public int switchReverserNeutral;
+        public int switchReverserBack;
+        public int switchHorn1;
+        public int switchHorn2;
+        public int switchMusicHorn;
+        public int switchConstSpeed;
+
+        static ConfigProfile()
+        {
+            FormStringConverter converter = new FormStringConverter();
+            Empty = new ConfigProfile()
+            {
+                switchS = converter.fromSwitchString("OFF"),
+                switchA1 = converter.fromSwitchString("OFF"),
+                switchA2 = converter.fromSwitchString("OFF"),
+                switchB1 = converter.fromSwitchString("OFF"),
+                switchB2 = converter.fromSwitchString("OFF"),
+                switchC1 = converter.fromSwitchString("OFF"),
+                switchC2 = converter.fromSwitchString("OFF"),
+                switchD = converter.fromSwitchString("OFF"),
+                switchE = converter.fromSwitchString("OFF"),
+                switchF = converter.fromSwitchString("OFF"),
+                switchG = converter.fromSwitchString("OFF"),
+                switchH = converter.fromSwitchString("OFF"),
+                switchI = converter.fromSwitchString("OFF"),
+                switchJ = converter.fromSwitchString("OFF"),
+                switchK = converter.fromSwitchString("OFF"),
+                switchL = converter.fromSwitchString("OFF"),
+                switchReverserFront = converter.fromSwitchString("OFF"),
+                switchReverserNeutral = converter.fromSwitchString("OFF"),
+                switchReverserBack = converter.fromSwitchString("OFF"),
+                switchHorn1 = converter.fromSwitchString("OFF"),
+                switchHorn2 = converter.fromSwitchString("OFF"),
+                switchMusicHorn = converter.fromSwitchString("OFF"),
+                switchConstSpeed = converter.fromSwitchString("OFF"),
+            };
+        }
+
+        public static ConfigProfile fromFile(string path)
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(ConfigProfile));
+            FileStream fs = new FileStream(path, FileMode.Open);
+            ConfigProfile profile = (ConfigProfile)serializer.Deserialize(fs);
+            fs.Close();
+
+            return profile;
+        }
+
+        public void save(string path)
+        {
+            string directory = Path.GetDirectoryName(path);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            XmlSerializer serializer = new XmlSerializer(typeof(ConfigProfile));
+            FileStream fs = new FileStream(path, FileMode.Create);
+            serializer.Serialize(fs, this);
+            fs.Close();
+        }
+    }
+}

--- a/oneHandleInput/FileNameValidator.cs
+++ b/oneHandleInput/FileNameValidator.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace oneHandleInput
+{
+    internal class FileNameValidator
+    {
+        public static bool IsValid(string fileName)
+        {
+            if (Path.GetInvalidFileNameChars().Any(fileName.Contains)) return false;
+
+            try
+            {
+                _ = Path.GetFullPath(fileName);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/oneHandleInput/FormStringConverter.cs
+++ b/oneHandleInput/FormStringConverter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace oneHandleInput
+{
+    internal class FormStringConverter
+    {
+        public string toSwitchString(int n)
+        {
+            switch (n)
+            {
+                case -1: return "OFF";
+                default: return toString(n);
+            }
+        }
+
+        public int fromSwitchString(string s)
+        {
+            switch (s)
+            {
+                case "OFF": return -1;
+                default: return fromString(s);
+            }
+        }
+
+        public string toString(int n)
+        {
+            return n.ToString();
+        }
+
+        public int fromString(string s)
+        {
+            int n = 0;
+
+            try
+            {
+                n = int.Parse(s);
+            }
+            catch
+            {
+                n = 0;
+            }
+
+            return n;
+        }
+    }
+}

--- a/oneHandleInput/ProfileSet.cs
+++ b/oneHandleInput/ProfileSet.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace oneHandleInput
+{
+    public class ProfileSet
+    {
+        private const string SaveFileName = "lastLoaded.txt";
+
+        private readonly Dictionary<string, ConfigProfile> m_profiles;
+
+        public bool isInitialSetting { get; }
+        public ICollection<string> keys => m_profiles.Keys;
+        public string currentKey { get; set; }
+        public ConfigProfile currentProfile => m_profiles[currentKey];
+
+        private ProfileSet(Dictionary<string, ConfigProfile> profiles, string defaultKey, bool isInitialSetting)
+        {
+            if (defaultKey == null)
+            {
+                defaultKey = profiles.Keys.First();
+            }
+
+            m_profiles = profiles;
+            currentKey = defaultKey;
+            this.isInitialSetting = isInitialSetting;
+        }
+
+        public static ProfileSet load(string configDirectory)
+        {
+            string[] fileNames = Directory.GetFiles(configDirectory, "*.xml");
+            Dictionary<string, ConfigProfile> profiles = fileNames.ToDictionary(fileName => Path.GetFileNameWithoutExtension(fileName), ConfigProfile.fromFile);
+
+            string defaultKey;
+            bool isInitialSetting = false;
+            if (profiles.Count == 0)
+            {
+                profiles.Add("(既定)", ConfigProfile.Empty);
+                defaultKey = "(既定)";
+                isInitialSetting = true;
+            }
+            else
+            {
+                defaultKey = Path.GetFileNameWithoutExtension(fileNames[0]);
+            }
+
+            try
+            {
+                StreamReader sr = new StreamReader(Path.Combine(configDirectory, SaveFileName));
+                defaultKey = sr.ReadToEnd();
+                sr.Close();
+            }
+            catch
+            {
+            }
+
+            return new ProfileSet(profiles, defaultKey, isInitialSetting);
+        }
+
+        public void save(string configDirectory)
+        {
+            File.WriteAllText(Path.Combine(configDirectory, SaveFileName), currentKey);
+        }
+    }
+}

--- a/oneHandleInput/SaveAsForm.Designer.cs
+++ b/oneHandleInput/SaveAsForm.Designer.cs
@@ -1,0 +1,129 @@
+﻿namespace oneHandleInput
+{
+    partial class SaveAsForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.txtName = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.lblInfo = new System.Windows.Forms.Label();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.btnSave = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(13, 13);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(214, 12);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "新しいプロファイルの名前を指定してください。";
+            // 
+            // txtName
+            // 
+            this.txtName.Location = new System.Drawing.Point(12, 46);
+            this.txtName.Name = "txtName";
+            this.txtName.Size = new System.Drawing.Size(333, 19);
+            this.txtName.TabIndex = 1;
+            this.txtName.TextChanged += new System.EventHandler(this.txtName_TextChanged);
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(347, 49);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(25, 12);
+            this.label2.TabIndex = 2;
+            this.label2.Text = ".xml";
+            // 
+            // lblInfo
+            // 
+            this.lblInfo.AutoSize = true;
+            this.lblInfo.Font = new System.Drawing.Font("MS UI Gothic", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
+            this.lblInfo.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.lblInfo.Location = new System.Drawing.Point(13, 69);
+            this.lblInfo.Name = "lblInfo";
+            this.lblInfo.Size = new System.Drawing.Size(0, 12);
+            this.lblInfo.TabIndex = 3;
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(216, 86);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 4;
+            this.btnCancel.Text = "キャンセル";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // btnSave
+            // 
+            this.btnSave.Location = new System.Drawing.Point(297, 86);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(75, 23);
+            this.btnSave.TabIndex = 5;
+            this.btnSave.Text = "保存";
+            this.btnSave.UseVisualStyleBackColor = true;
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // SaveAsForm
+            // 
+            this.AcceptButton = this.btnSave;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(384, 121);
+            this.Controls.Add(this.btnSave);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.lblInfo);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.txtName);
+            this.Controls.Add(this.label1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Name = "SaveAsForm";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "プロファイルの新規保存";
+            this.TopMost = true;
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox txtName;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label lblInfo;
+        private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Button btnSave;
+    }
+}

--- a/oneHandleInput/SaveAsForm.cs
+++ b/oneHandleInput/SaveAsForm.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace oneHandleInput
+{
+    public partial class SaveAsForm : Form
+    {
+        private readonly string m_directory;
+
+        public bool isValid { get; private set; } = false;
+        public string newName => isValid ? txtName.Text : null;
+
+        public SaveAsForm(string directory, string defaultName)
+        {
+            InitializeComponent();
+
+            m_directory = directory;
+            txtName.Text = defaultName;
+            txtName.SelectAll();
+        }
+
+        private void txtName_TextChanged(object sender, EventArgs e)
+        {
+            string newName = txtName.Text;
+            if (newName == string.Empty)
+            {
+                SetErrorText("このファイル名は使用できません。");
+                isValid = false;
+            }
+            else if (!FileNameValidator.IsValid(newName))
+            {
+                SetErrorText("ファイル名に使用できない文字が含まれています。");
+                isValid = false;
+            }
+            else if (File.Exists(Path.Combine(m_directory, newName + ".xml")))
+            {
+                SetErrorText("このファイル名は既に使用されています。");
+                isValid = false;
+            }
+            else
+            {
+                SetInfoText("このファイル名は使用可能です。");
+                isValid = true;
+            }
+
+            btnSave.Enabled = isValid;
+        }
+
+        private void SetInfoText(string text)
+        {
+            lblInfo.Text = text;
+            lblInfo.ForeColor = SystemColors.ControlText;
+        }
+
+        private void SetErrorText(string text)
+        {
+            lblInfo.Text = text;
+            lblInfo.ForeColor = Color.Red;
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            if (!isValid) return;
+
+            this.DialogResult = DialogResult.OK;
+            this.Close();
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+            this.Close();
+        }
+    }
+}

--- a/oneHandleInput/SaveAsForm.resx
+++ b/oneHandleInput/SaveAsForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/oneHandleInput/directInputApi.cs
+++ b/oneHandleInput/directInputApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 using SlimDX.DirectInput;
 

--- a/oneHandleInput/oneHandleInput.cs
+++ b/oneHandleInput/oneHandleInput.cs
@@ -25,8 +25,7 @@ namespace oneHandleInput
             m_first = true;
             directInputApi.init();
 
-            m_configForm = new ConfigForm();
-            m_configForm.loadConfigurationFile(settingsPath);
+            m_configForm = new ConfigForm(settingsPath);
             m_configForm.Hide();
 
             m_lastReverserPos = 0xFFFF;
@@ -77,9 +76,12 @@ namespace oneHandleInput
 
         private void setSwitchState()
         {
+            SlimDX.DirectInput.Device currentJoystick = directInputApi.currentJoystick;
+            if (currentJoystick == null) return;
+
             var currentButtonState = directInputApi.currentJoystickState.GetButtons();
             var lastButtonState = directInputApi.lastJoystickState.GetButtons();
-            int buttonNum = directInputApi.currentJoystick.Capabilities.ButtonCount;
+            int buttonNum = currentJoystick.Capabilities.ButtonCount;
 
             for (int i = 0; i < buttonNum; ++i)
             {
@@ -159,7 +161,7 @@ namespace oneHandleInput
         private int getKeyIdx(int i)
         {
             int keyIdx = -1;
-            ConfigForm.ConfigFormSaveData config = m_configForm.Configuration;
+            ConfigProfile config = m_configForm.currentProfile;
 
             if (config.switchS == i)
             {
@@ -259,7 +261,7 @@ namespace oneHandleInput
 
         private void setPowerPos()
         {
-            ConfigForm.ConfigFormSaveData config = m_configForm.Configuration;
+            ConfigProfile config = m_configForm.currentProfile;
             int notchPos = 0;
 
             if (config.powerAxis == (int)ConfigForm.AxisType.axisNothing)
@@ -306,7 +308,7 @@ namespace oneHandleInput
 
         private void setSsbPos()
         {
-            ConfigForm.ConfigFormSaveData config = m_configForm.Configuration;
+            ConfigProfile config = m_configForm.currentProfile;
             int notchPos = 0;
 
             if (config.ssbAxis == (int)ConfigForm.AxisType.axisNothing)
@@ -353,7 +355,7 @@ namespace oneHandleInput
 
         private void setBrakePos()
         {
-            ConfigForm.ConfigFormSaveData config = m_configForm.Configuration;
+            ConfigProfile config = m_configForm.currentProfile;
             int notchPos = 0;
             bool force_move = false;
 
@@ -419,7 +421,7 @@ namespace oneHandleInput
 
         private void setReverserPos()
         {
-            ConfigForm.ConfigFormSaveData config = m_configForm.Configuration;
+            ConfigProfile config = m_configForm.currentProfile;
             int notchPos = 0;
 
             if (config.reverserAxis == (int)ConfigForm.AxisType.axisNothing)

--- a/oneHandleInput/oneHandleInput.csproj
+++ b/oneHandleInput/oneHandleInput.csproj
@@ -84,13 +84,26 @@
     <Compile Include="ConfigForm.Designer.cs">
       <DependentUpon>ConfigForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="ConfigProfile.cs" />
     <Compile Include="directInputApi.cs" />
+    <Compile Include="FileNameValidator.cs" />
     <Compile Include="oneHandleInput.cs" />
+    <Compile Include="ProfileSet.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="FormStringConverter.cs" />
+    <Compile Include="SaveAsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="SaveAsForm.Designer.cs">
+      <DependentUpon>SaveAsForm.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="ConfigForm.resx">
       <DependentUpon>ConfigForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="SaveAsForm.resx">
+      <DependentUpon>SaveAsForm.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
複数マスコンを併用している環境において、マスコンを取りかえる度に設定値を全て書き換えなければならず煩雑……との声があったため作成しました。
下の画像のように、コンボボックスからプロファイルを切り替えられる仕様となっています。

![image](https://github.com/mikangogo/oneHandleInput/assets/67314487/da526edf-c0e2-40e3-9c05-7ccb0519fd2a)

### [名前を付けて保存] 押下時の挙動
![image](https://github.com/mikangogo/oneHandleInput/assets/67314487/aeb96e73-74b4-4b3d-8254-825ae8c002a7)

作成したプロファイルは `BveTs\Settings\oneHandleInput\` 内に保存されます。どのプロファイルを選択しているかは次回起動時にも引き継がれます (`BveTs\Settings\oneHandleInput\lastLoaded.txt` に保存しています)。

## ベース ブランチについて
master との差分 (e28f7dd136e26c62c95a2fb7def0d706fb462263) にて C# コードが編集されており、master へこのプルリクエストをマージした場合コンフリクトが生じてしまうため、プルリクエストの送信先を feature/support-bve6 としました。もしご都合が悪ければお知らせください。